### PR TITLE
docs: fix typo

### DIFF
--- a/docs/development/workspace.ja.md
+++ b/docs/development/workspace.ja.md
@@ -53,7 +53,7 @@ cd /aichallenge
 Autowareのビルド後、以下のコマンドを実行します。
 
 ```bash
-./run_autoware.sh
+./run_autoware.bash
 ```
 
 下記の様な画面が表示されたら起動完了です。終了するにはターミナル上でCTRL + Cを入力します。


### PR DESCRIPTION
チームメンバーから、"run_autoware.sh" が失敗し、代わりに "run_autoware.bash" を実行すると成功したとの情報があり、
一旦 pull request させてもらいました。 
ただ何が正しいかよくわかっておらず、もし認識ズレていましたらpull request破棄して頂いて構いません。

