### PR TITLE
docs: fix typo and add some setup steps

### DIFF
--- a/docs/course/index.ja.md
+++ b/docs/course/index.ja.md
@@ -8,6 +8,21 @@
 
 ## 環境構築
 
+まず､ Autoware の動作に必要な ROS 2 をインストールします｡
+[ROS 2 Documentation](https://docs.ros.org/en/humble/Installation/Ubuntu-Install-Debians.html) の手順にしたがってインストールしてください｡
+
+つづけて､いくつかの開発支援ツールセットもインストールします｡
+
+```bash
+# Install rosdep
+sudo apt install python3-rosdep
+# Install vcstool
+sudo apt install python3-vcstool
+# Install colcon
+sudo apt install python3-colcon-common-extensions
+```
+
+
 任意のディレクトリにて入門講座のリポジトリをクローンし、ビルドを行ってください。
 
 ```bash

--- a/docs/course/velocity_planning.md
+++ b/docs/course/velocity_planning.md
@@ -181,7 +181,7 @@ ros2 bag record -o velocity.bag /localization/kinematic_state
 
 PlotJugglerは以下のコマンドで、インストールすることができます。
 ```bash
-sudo apt install ros-humble plotjuggler-ros
+sudo apt install ros-humble-plotjuggler-ros
 ```
 
 そして以下のコマンドでPlotJugglerを起動します。


### PR DESCRIPTION
ドキュメント内容の追加と､typo修正のPRです｡
具体的な内容は以下の通りです｡( #24 から転記)

* [講座>Autoware入門講座](https://automotiveaichallenge.github.io/aichallenge-documentation-2024/course/) ページ
  * 依存パッケージについて､インストール手順について言及があるとより分かりやすいと思いました｡
    * [ROS 2 Humbleのインストール](https://docs.ros.org/en/humble/Installation.html)
    * rosdepのインストール
    ```
    sudo apt install python3-rosdep
    ```
    * vcstoolのインストール
    ```
    $ sudo apt install python3-vcstool
    ```
    * colconのインストール
    ```
    $ sudo apt install python3-colcon-common-extensions
    ```

* [講座>0.2 速度計画](https://automotiveaichallenge.github.io/aichallenge-documentation-2024/course/velocity_planning/) ページ
  * Typo
    * (現状) 
    ```
    sudo apt install ros-humble plotjuggler-ros
    ```
    * (正)
    ```
    sudo apt install ros-humble-plotjuggler-ros
    ```