### PR TITLE
fix: spelling inconsistencies

### DIFF
--- a/docs/index.ja.md
+++ b/docs/index.ja.md
@@ -49,6 +49,6 @@
 
 ## 使用車両
 
-![TOM'S RacingKart](./images/RacingKart.jpeg)
+![TOM'S Racing Kart](./assets/racing-kart.jpeg)
 
 ## 挑戦課題

--- a/docs/specifications/simulator.en.md
+++ b/docs/specifications/simulator.en.md
@@ -6,9 +6,9 @@ This page describes the specifications of the simulator used in the AI Challenge
 
 The simulator is based on the open-source autonomous driving simulator "[AWSIM](https://github.com/tier4/AWSIM)" developed for Autoware.
 
-## Vehicle (Go-Kart)
+## Vehicle (Racing Kart)
 
-The vehicle conforms to the specifications of the [EGO Vehicle](https://tier4.github.io/AWSIM/Components/Vehicle/EgoVehicle/) in AWSIM and is designed with specifications close to an actual go-kart.
+The vehicle conforms to the specifications of the [EGO Vehicle](https://tier4.github.io/AWSIM/Components/Vehicle/EgoVehicle/) in AWSIM and is designed with specifications close to an actual racing kart.
 
 ![vehicle-appearance](./images/vehicle-appearance.png)
 

--- a/docs/specifications/simulator.ja.md
+++ b/docs/specifications/simulator.ja.md
@@ -6,9 +6,9 @@
 
 シミュレーターは、Autowareのためのオープンソース自動運転シミュレーター「[AWSIM](https://github.com/tier4/AWSIM)」をベースとして作成されています。
 
-## 車両（ゴーカート）
+## 車両（レーシングカート）
 
-車両はAWSIMにおける[EGO Vehicle](https://tier4.github.io/AWSIM/Components/Vehicle/EgoVehicle/)の仕様に準拠しており、実際のゴーカートに近いスペックで作成されています。
+車両はAWSIMにおける[EGO Vehicle](https://tier4.github.io/AWSIM/Components/Vehicle/EgoVehicle/)の仕様に準拠しており、実際のレーシングカートに近いスペックで作成されています。
 
 ![vehicle-appearance](./images/vehicle-appearance.png)
 


### PR DESCRIPTION
車両がゴーカートとレーシングカートで表記ゆれしていたので、レーシングカートに統一しました。