### PR TITLE
feat: add announcement banner for registration

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,1 +1,2 @@
 *.md
+overrides

--- a/docs/stylesheets/custom.css
+++ b/docs/stylesheets/custom.css
@@ -14,3 +14,16 @@ h1 {
   border-bottom: 2px solid #b70000;
   background-color: #15151e;
 }
+
+.md-banner {
+  background-color: #15151e;
+}
+
+.banner-button {
+  background-color: #b70000 !important;
+}
+
+.banner-button:hover {
+  background-color: #15151e !important;
+  border: 2px solid #b70000 !important;
+}

--- a/mkdocs.yaml
+++ b/mkdocs.yaml
@@ -7,10 +7,12 @@ use_directory_urls: false
 
 theme:
   name: material
+  custom_dir: overrides
   features:
     - navigation.tabs
     - navigation.tabs.sticky
     - toc.integrate
+    - announce.dismiss
   palette:
     scheme: slate
     primary: custom

--- a/overrides/main.html
+++ b/overrides/main.html
@@ -1,0 +1,5 @@
+{% extends "base.html" %}
+
+{% block announce %}
+  誰でも参加登録できます！　<a href="https://docs.google.com/forms/d/e/1FAIpQLSc0xFCrNS_J5Bl2g2RIZ694B5p9vOhlav9hrwgumtBrQuQ0RQ/viewform" class="md-button md-button--primary banner-button" target="_blank">自動運転AIチャレンジに参加登録はこちら！</a>
+{% endblock %}


### PR DESCRIPTION
- 参加登録ボタンを全ページの上部のアナウンスメントバナーに表示されるように追加
- バナーは、画面を下にスクロールすると消えるので画面の邪魔にはならない

![image](https://github.com/AutomotiveAIChallenge/aichallenge-documentation-2024/assets/5180742/3d10b787-397b-43dd-8dcc-2d7c22146577)
