### PR TITLE
docs: add details about ROS 2 installation

### DIFF
--- a/docs/course/index.ja.md
+++ b/docs/course/index.ja.md
@@ -9,7 +9,7 @@
 ## 環境構築
 
 まず､ Autoware の動作に必要な ROS 2 をインストールします｡
-[ROS 2 Documentation](https://docs.ros.org/en/humble/Installation/Ubuntu-Install-Debians.html) の手順にしたがってインストールしてください｡
+[ROS 2 Documentation](https://docs.ros.org/en/humble/Installation/Ubuntu-Install-Debians.html) の手順にしたがってEnvironment setupまでを完了させてください｡
 
 つづけて､いくつかの開発支援ツールセットもインストールします｡
 


### PR DESCRIPTION
ROS 2のインストール手順のどこまでをやればいいのか不明瞭だったので記述を追加しました。