### PR TITLE
fix: delete AWSIM and the map link

### DIFF
--- a/docs/development/workspace-usage.en.md
+++ b/docs/development/workspace-usage.en.md
@@ -60,7 +60,7 @@ It would be best if you proceed as follows.
 
 For the 2024 AI Challenge, we recommend editing maps such as point cloud maps and lanelet2 maps using tools like [VectorMapBuilder](https://tools.tier4.jp/feature/vector_map_builder_ll2/) .
 
-Download and edit the point cloud map, lanelet2 map, etc., from the [Map file storage](https://drive.google.com/drive/folders/1nsYIg_3rwIjg0x6BC__aWVmnv-25nZkn) !
+Download and edit the point cloud map, lanelet2 map, etc., from the Map file storage! (The map distribution has ended.)
 
 Refer to the [VectorMapBuilder usage video](https://www.youtube.com/watch?v=GvZr707TmuM) for step-by-step instructions.
 

--- a/docs/development/workspace-usage.ja.md
+++ b/docs/development/workspace-usage.ja.md
@@ -60,7 +60,7 @@ AIチャレンジではオープンソースソフトウェアを駆使してい
 
 2024年度のAIチャレンジでは[VectorMapBuilder](https://tools.tier4.jp/feature/vector_map_builder_ll2/)などのツールを使ってpoint cloud map , lanelet2 mapなどの地図の編集を推奨しています。
 
-[Mapのファイル置き場](https://drive.google.com/drive/folders/1nsYIg_3rwIjg0x6BC__aWVmnv-25nZkn)からpointcloud map lanelet2 mapなどをダウンロードして編集してみましょう！
+Mapのファイル置き場からpointcloud map lanelet2 mapなどをダウンロードして編集してみましょう！（Mapの配布は終了しました）
 
 [VectorMapBuilderの使い方動画](https://www.youtube.com/watch?v=GvZr707TmuM)にステップバイステップのインストラクションなどがあるので参考にしてみてください。
 

--- a/docs/setup/headless-simulation.en.md
+++ b/docs/setup/headless-simulation.en.md
@@ -1,8 +1,8 @@
 # Downloading Headless AWSIM
 
-## Download AWSIM
+## Download AWSIM (The simulator distribution has ended.)
 
-1. Download the latest `AWSIM_GPU_**.zip` file from [Google Drive](https://drive.google.com/drive/folders/1ftIoamNGAet90sXeG48lKa89dkpVy45y) and extract it to `aichallenge-2024/aichallenge/simulator`.
+1. Download the latest `AWSIM_GPU_**.zip` file from Google Drive and extract it to `aichallenge-2024/aichallenge/simulator`.
 
 2. Confirm that the executable file exists at `aichallenge-2024/aichallenge/simulator/AWSIM/AWSIM.x86_64`.
 

--- a/docs/setup/headless-simulation.ja.md
+++ b/docs/setup/headless-simulation.ja.md
@@ -1,8 +1,8 @@
 # 描画なしAWSIMのダウンロード
 
-## AWSIMのダウンロード
+## AWSIMのダウンロード（シミュレータの配布は終了しました）
 
-1. [Google Drive](https://drive.google.com/drive/folders/1ftIoamNGAet90sXeG48lKa89dkpVy45y) から最新の `AWSIM.zip` をダウンロードし、`aichallenge-2024/aichallenge/simulator` に展開します。
+1. Google Driveから最新の `AWSIM.zip` をダウンロードし、`aichallenge-2024/aichallenge/simulator` に展開します。
 
 2. 実行ファイルが`aichallenge-2024/aichallenge/simulator/AWSIM/AWSIM.x86_64`に存在していることを確認してください。
 

--- a/docs/setup/visible-simulation.en.md
+++ b/docs/setup/visible-simulation.en.md
@@ -74,9 +74,9 @@ sudo apt update
 sudo apt install -y libvulkan1
 ```
 
-## Downloading AWSIM
+## Downloading AWSIM (The simulator distribution has ended.)
 
-1. Download the latest `AWSIM_GPU_**.zip` file from [Google Drive](https://drive.google.com/drive/folders/1ftIoamNGAet90sXeG48lKa89dkpVy45y) and extract it to `aichallenge-2024/aichallenge/simulator`.
+1. Download the latest `AWSIM_GPU_**.zip` file from Google Drive and extract it to `aichallenge-2024/aichallenge/simulator`.
 
 2. Confirm that the executable file exists at `aichallenge-2024/aichallenge/simulator/AWSIM/AWSIM.x86_64`.
 

--- a/docs/setup/visible-simulation.ja.md
+++ b/docs/setup/visible-simulation.ja.md
@@ -74,9 +74,9 @@ sudo apt update
 sudo apt install -y libvulkan1
 ```
 
-## AWSIMのダウンロード
+## AWSIMのダウンロード（シミュレータの配布は終了しました）
 
-1. [Google Drive](https://drive.google.com/drive/folders/1ftIoamNGAet90sXeG48lKa89dkpVy45y) から最新の `AWSIM_GPU_**.zip` をダウンロードし、`aichallenge-2024/aichallenge/simulator` に展開します。
+1. Google Drive から最新の `AWSIM_GPU_**.zip` をダウンロードし、`aichallenge-2024/aichallenge/simulator` に展開します。
 
 2. 実行ファイルが`aichallenge-2024/aichallenge/simulator/AWSIM/AWSIM.x86_64`に存在していることを確認してください。
 


### PR DESCRIPTION
AWSIMの公開を終了するので、AWSIMが格納されているgdriveのリンクを削除しました。
地図のリンクも切れていたので削除しました。

### Related link
slack [TIER IV internal link](https://star4.slack.com/archives/C06KJQP1B09/p1732507201858479?thread_ts=1732504875.343359&cid=C06KJQP1B09)